### PR TITLE
Improve installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,16 @@
-#######################
-### COMPILED SOURCE ###
-#######################
-*.pyc
-*.swp
-build/
+# files created by planners
+outcmaes/
+
+############
+### LOGS ###
+############
+*olympus*.pkl
 
 #################
 ### DATABASES ###
 #################
 *.db
 *scratch*
-
-############
-### LOGS ###
-############
-*.log
-*olympus*.pkl
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -39,27 +34,119 @@ parts/
 sdist/
 var/
 wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
 *.cover
+*.py,cover
 .hypothesis/
 .pytest_cache/
+cover/
 
-# pycharm stuff
-.idea/
+# Translations
+*.mo
+*.pot
 
-# ipynb checkpoints
-*.ipynb_checkpoints/
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
 
-# files created by planners
-outcmaes/
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-numpy 
+numpy
 Cython
+sqlalchemy
+tensorflow==2.*,>=2.2.0
+tensorflow-probability==0.*,>=0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 Cython
-sqlalchemy
+sqlalchemy  
 tensorflow==2.*,>=2.2.0
-tensorflow-probability==0.*,>=0.10.1
+tensorflow-probability==0.*,>=0.10.1git

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python 
 
-import versioneer
-import numpy as np
+# import versioneer
+# import numpy as np
 
 from setuptools import setup, find_packages
 from distutils.extension import Extension
+from distutils.command.build import build as build_orig
 
 #===============================================================================
 
@@ -14,39 +15,31 @@ def readme():
 
 #===============================================================================
 
-try: 
-	from Cython.Distutils import build_ext
-	from Cython.Build     import cythonize
-except ImportError:
-	use_cython = False
-else:
-	use_cython = True
+ext_modules = [
+	Extension('gryffin.bayesian_network.kernel_evaluations',
+		['src/gryffin/bayesian_network/kernel_evaluations.c']),
+	Extension('gryffin.bayesian_network.kernel_prob_reshaping',
+		['src/gryffin/bayesian_network/kernel_prob_reshaping.c']),]
 
-cmdclass    = {}
-ext_modules = []
-use_cython = False
 
-if use_cython:
-	ext_modules += [
-		Extension('gryffin.bayesian_network.kernel_evaluations',
-			['src/gryffin/bayesian_network/kernel_evaluations.pyx']),
-		Extension('gryffin.bayesian_network.kernel_prob_reshaping',
-			['src/gryffin/bayesian_network/kernel_prob_reshaping.pyx']),]
-	ext_modules = cythonize(ext_modules)
-	cmdclass.update({'build_ext': build_ext})
-else:
-	ext_modules += [
-		Extension('gryffin.bayesian_network.kernel_evaluations',
-			['src/gryffin/bayesian_network/kernel_evaluations.c']),
-		Extension('gryffin.bayesian_network.kernel_prob_reshaping',
-			['src/gryffin/bayesian_network/kernel_prob_reshaping.c']),]
+class build(build_orig):
+
+    def finalize_options(self):
+        super().finalize_options()
+        # I stole this line from ead's answer:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        # or just modify my_c_lib_ext directly here, ext_modules should contain a reference anyway
+        extension = next(m for m in self.distribution.ext_modules if m == ext_modules[0])
+        extension.include_dirs.append(numpy.get_include())
+
 
 #===============================================================================
 
 setup(name='gryffin',
 	#version=versioneer.get_version(),
 	version='0.1.0',
-        cmdclass=versioneer.get_cmdclass(),
+    # cmdclass=versioneer.get_cmdclass(),
 	description='Bayesian optimization for categorical variables', 
 	long_description=readme(),
 	long_description_content_type='text/markdown',
@@ -62,11 +55,11 @@ setup(name='gryffin',
 	package_dir={'': 'src'},
 	zip_safe=False,
 	ext_modules=ext_modules,
+	cmdclass={'build': build},
 	tests_require=['pytest'],
 	install_requires=[
 		'numpy',
 		'sqlalchemy',
 		],
-	include_dirs=np.get_include(),
 	python_requires='>=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -21,18 +21,14 @@ ext_modules = [
 	Extension('gryffin.bayesian_network.kernel_prob_reshaping',
 		['src/gryffin/bayesian_network/kernel_prob_reshaping.c']),]
 
+# Preinstall numpy
+from setuptools import dist
+dist.Distribution().fetch_build_eggs(['numpy>=1.10'])
+import numpy as np
 
-class build(build_orig):
-
-    def finalize_options(self):
-        super().finalize_options()
-        # I stole this line from ead's answer:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        # or just modify my_c_lib_ext directly here, ext_modules should contain a reference anyway
-        extension = next(m for m in self.distribution.ext_modules if m == ext_modules[0])
-        extension.include_dirs.append(numpy.get_include())
-
+def requirements():
+	with open('requirements.txt', 'r') as content:
+		return content.readlines()
 
 #===============================================================================
 
@@ -55,11 +51,8 @@ setup(name='gryffin',
 	package_dir={'': 'src'},
 	zip_safe=False,
 	ext_modules=ext_modules,
-	cmdclass={'build': build},
 	tests_require=['pytest'],
-	install_requires=[
-		'numpy',
-		'sqlalchemy',
-		],
+	include_dirs=np.get_include(),
+	install_requires=requirements(),
 	python_requires='>=3.6',
 )


### PR DESCRIPTION
The installation previously did not work correctly due to an issue with numpy being needed at setup but not installed. Used the [following code](https://stackoverflow.com/questions/54117786/add-numpy-get-include-argument-to-setuptools-without-preinstalled-numpy) to fix that:

```python
from setuptools import dist
dist.Distribution().fetch_build_eggs(['numpy>=1.10'])
```

Also, some dependencies were missing in the installation. I fixed that as well.